### PR TITLE
Fix favicon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/avatar.png" />
+    <link rel="icon" type="image/png" href="avatar.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Igor Ladkin</title>
   </head>


### PR DESCRIPTION
## Summary
- fix static favicon path so it works when deployed under /resume

## Testing
- `npm run build` *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_e_6842d47617108324a22341ef70f721f6