### PR TITLE
Correct ElasticSearch spelling

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -19,7 +19,7 @@ function Experience() {
         <ul className="list-disc list-inside">
           <li>
             Architected and implemented a high-performance candidate profile
-            service with sophisticated ElasticSearch capabilities, enabling
+            service with sophisticated Elasticsearch capabilities, enabling
             precise talent matching through seamless integration with multiple
             LLM systems and advanced caching strategies.
           </li>
@@ -95,7 +95,7 @@ function Experience() {
             experience.
           </li>
           <li>
-            Optimized ElasticSearch query performance through refined index
+            Optimized Elasticsearch query performance through refined index
             schemas and scoring algorithms, significantly enhancing the accuracy
             of driver-passenger matching.
           </li>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -3,7 +3,7 @@ function Skills() {
     <div className="flex flex-col gap-2">
       <h2 className="text-lg font-semibold">Skills</h2>
       <p>
-        Ruby, JavaScript, Elixir, Python, Go, SQL, CI/CD, ElasticSearch, Redis,
+        Ruby, JavaScript, Elixir, Python, Go, SQL, CI/CD, Elasticsearch, Redis,
         OpenAI, problem solving, technical writing and documentation, building
         products from ground up.
       </p>


### PR DESCRIPTION
## Summary
- fix typos: ElasticSearch -> Elasticsearch in `Experience.tsx`
- fix typo in `Skills.tsx`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842d626670483248356772b5a500549